### PR TITLE
chore(task-13): update CODEOWNERS for GitHub org rename

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,8 +1,8 @@
 # Ensure that changes to the terraform directory are reviewed by the infrastructure team
-*.tf @ElectroRoute-Japan/Cranes
-*.hcl @ElectroRoute-Japan/Cranes
+*.tf @EnergyRoute-Japan/Cranes
+*.hcl @EnergyRoute-Japan/Cranes
 
 # Ensure that changes to workflows or the codeowners file are reviewed by the Admins
-.gitignore @ElectroRoute-Japan/Admins
-CODEOWNERS @ElectroRoute-Japan/Admins
-LICENSE @ElectroRoute-Japan/Admins
+.gitignore @EnergyRoute-Japan/Admins
+CODEOWNERS @EnergyRoute-Japan/Admins
+LICENSE @EnergyRoute-Japan/Admins


### PR DESCRIPTION
Updates CODEOWNERS team references from `@ElectroRoute-Japan/*` to `@EnergyRoute-Japan/*` following the GitHub organisation rename.

Part of task CU-869d478xw.